### PR TITLE
Removing from Run Loop after curl finished

### DIFF
--- a/XBPageCurl/XBCurlView.m
+++ b/XBPageCurl/XBCurlView.m
@@ -848,6 +848,7 @@ void MultiplyM4x4(const GLfloat *A, const GLfloat *B, GLfloat *out);
 - (void)stopAnimating
 {
     [self.displayLink invalidate];
+    [self.displayLink removeFromRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
     self.displayLink = nil;
 }
 


### PR DESCRIPTION
Added code for removing from Run Loop task when stopAnimating called.
If this is not done CPU load becomes very high, and grows when new instances of XBCurlView allocated.
